### PR TITLE
Updates checking for equality instead of identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+ankidown/forms/__init__.py

--- a/ankidown/importer.py
+++ b/ankidown/importer.py
@@ -124,7 +124,7 @@ class AnkidownImporter(AddCards):
             self.setBuffer(0)
 
     def prevNote(self):
-        if self.bufferIndex is 0:
+        if self.bufferIndex == 0:
             self.setBuffer(len(self.buffer) - 1)
         else:
             self.setBuffer(self.bufferIndex - 1)

--- a/ankidown/template.py
+++ b/ankidown/template.py
@@ -82,7 +82,7 @@ class TemplaterWidget:
         template_list = ["Create new Template..."] + list(config["templates"].keys())
         selection = chooseList("Select a Template:", template_list)
 
-        if selection is 0:
+        if selection == 0:
             name = getOnlyText("New Template name:")
             if not name:
                 return


### PR DESCRIPTION
There is a problem with python 3.8 that checking for identity with the `is`statement, generating an syntax error:

> "is" with a literal. Did you mean "==" ? 

Just changed that.
Hope you are open for pull requests. :) Maybe I write some more...
Thank!
